### PR TITLE
[WIP] feature: Create and CreateN

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,29 @@ func UserFactory(h facto.Helper) facto.Product {
 
 When the factory gets called individually Index will be 0.
 
+#### Create and CreateN
+
+Besides building your products there are 2 handy methods, Create and CreateN, that will call a established Creator to create desired records in application persistence layer.
+
+Before calling each of these methods you need to register a Creator instance, to do so you use the `facto.SetCreator` function.
+
+```go
+func TestUserCreated(t *testing.T) {
+    // register a creator
+    facto.SetCreator(UserCreator{})
+
+    // create a user
+    user := facto.Create("User").(models.User)
+    // use user for test purposes ...
+
+    // create N users
+    users := facto.CreateN("User", 10).([]models.User)
+    // use users for test purposes ...
+}
+```
+
+When there is no registered creator, the `Create` and `CreateN` methods will return an error.
+
 ### Dependent factories
 
 Another case is when you need to build an object that depends on another object. You can use the `factory.Helper` parameter on your factory to get the object you need:
@@ -205,6 +228,7 @@ func EventFactory(h facto.Helper) facto.Product {
     return facto.Product(event)
 })
 ```
+
 
 ### The CLI
 

--- a/creator.go
+++ b/creator.go
@@ -1,0 +1,49 @@
+package facto
+
+import (
+	"fmt"
+	"reflect"
+)
+
+var (
+	// creator shared instance to be used by Create and CreateN
+	creator Creator
+
+	ErrNoCreatorDefined = fmt.Errorf("no creator set")
+)
+
+// sets the creator for Facto.
+func SetCreator(c Creator) {
+	creator = c
+}
+
+// Creator allows to persist the record in the database
+// a creator is anything that has a Create method that receives
+// an interface and returns an error in case it fails.
+type Creator interface {
+	Create(interface{}) error
+}
+
+type MemoryCreator struct {
+	created []interface{}
+}
+
+func (mc *MemoryCreator) Create(i interface{}) error {
+	mc.created = append(mc.created, i)
+
+	return nil
+}
+
+func (mc *MemoryCreator) Contains(i interface{}) bool {
+	if len(mc.created) == 0 {
+		return false
+	}
+
+	for _, c := range mc.created {
+		if reflect.DeepEqual(c, i) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/creator.go
+++ b/creator.go
@@ -12,7 +12,7 @@ var (
 	ErrNoCreatorDefined = fmt.Errorf("no creator set")
 )
 
-// sets the creator for Facto.
+// SetCreator that CreateN and Create will use when invoked.
 func SetCreator(c Creator) {
 	creator = c
 }
@@ -24,6 +24,10 @@ type Creator interface {
 	Create(interface{}) error
 }
 
+// MemoryCreator is a creator that serves as a way to test
+// the creation of records. Its not intended to be used in
+// production as it is not thread safe. It is also intended
+// to show how to implement a Creator in case don't have one.
 type MemoryCreator struct {
 	created []interface{}
 }

--- a/facto.go
+++ b/facto.go
@@ -1,6 +1,7 @@
 package facto
 
 import (
+	"fmt"
 	"reflect"
 )
 
@@ -29,4 +30,34 @@ func BuildN(f Factory, n int) Product {
 	}
 
 	return Product(products.Interface())
+}
+
+// Create a record using the configured creator. It calls the Build function
+// and then passes the result product to the creator.
+func Create(f Factory) (Product, error) {
+	if creator == nil {
+		return nil, ErrNoCreatorDefined
+	}
+
+	p := Build(f)
+	if err := creator.Create(p); err != nil {
+		return p, fmt.Errorf("could not create products: %w", err)
+	}
+
+	return p, nil
+}
+
+// Create n records of a given factory. It calls BuildN and then
+// passes the result to the creator.
+func CreateN(f Factory, n int) (Product, error) {
+	if creator == nil {
+		return nil, ErrNoCreatorDefined
+	}
+
+	p := BuildN(f, n)
+	if err := creator.Create(p); err != nil {
+		return p, fmt.Errorf("could not create products: %w", err)
+	}
+
+	return p, nil
 }

--- a/factories_test.go
+++ b/factories_test.go
@@ -1,0 +1,98 @@
+package facto_test
+
+import (
+	"fmt"
+
+	"github.com/gofrs/uuid"
+	"github.com/wawandco/facto"
+)
+
+type user struct {
+	Name string
+}
+
+type event struct {
+	Name string
+	User user
+}
+
+type company struct {
+	ID           uuid.UUID
+	Name         string
+	Address      string
+	ContactEmail string
+	Users        []user
+}
+
+type department struct {
+	Name      string
+	CompanyID uuid.UUID
+	Company   company
+}
+
+type OtherUser struct {
+	FirstName string
+	LastName  string
+	Email     string
+	Company   string
+	Address   string
+}
+
+func UserNFactory(f facto.Helper) facto.Product {
+	u := user{
+		Name: fmt.Sprintf("Wawandco %d", f.Index),
+	}
+	return facto.Product(u)
+}
+
+func UserFactory(f facto.Helper) facto.Product {
+	u := user{
+		Name: "Wawandco",
+	}
+	return facto.Product(u)
+}
+
+func OtherUserFactory(f facto.Helper) facto.Product {
+	u := OtherUser{
+		FirstName: f.Faker.FirstName(),
+		LastName:  f.Faker.LastName(),
+		Email:     f.Faker.Email(),
+		Company:   f.Faker.Company(),
+		Address:   f.Faker.Address().Address,
+	}
+
+	return facto.Product(u)
+}
+
+func EventFactory(f facto.Helper) facto.Product {
+	u := event{
+		Name: "CLICK",
+		User: facto.Build(UserFactory).(user),
+	}
+
+	return facto.Product(u)
+}
+
+func CompanyFactory(h facto.Helper) facto.Product {
+	u := company{
+		ID:           h.NamedUUID("company_id"),
+		Name:         h.Faker.Name(),
+		Address:      h.Faker.Address().Address,
+		ContactEmail: h.Faker.Email(),
+
+		// Building N Users
+		Users: facto.BuildN(UserFactory, 5).([]user),
+	}
+
+	return facto.Product(u)
+}
+
+func DepartmentFactory(f facto.Helper) facto.Product {
+	u := department{
+		Name:      "Technology",
+		CompanyID: f.NamedUUID("company_id"),
+		Company:   facto.Build(CompanyFactory).(company),
+	}
+
+	return facto.Product(u)
+}

--- a/generate_test.go
+++ b/generate_test.go
@@ -24,7 +24,7 @@ func TestCammelCase(t *testing.T) {
 		t.Run(v.in, func(t *testing.T) {
 			out := camelCase(v.in)
 			if out != v.want {
-				t.Errorf("camelCase(%q) = %q, want %q", v.in, out, v.want)
+				t.Fatalf("camelCase(%q) = %q, want %q", v.in, out, v.want)
 			}
 		})
 	}
@@ -58,7 +58,7 @@ func TestSnakeCase(t *testing.T) {
 		result := snakeCase(v.input)
 
 		if result != v.expected {
-			t.Errorf("snakeCase(%q) = %q, want %q", v.input, result, v.expected)
+			t.Fatalf("snakeCase(%q) = %q, want %q", v.input, result, v.expected)
 		}
 	}
 }
@@ -78,11 +78,11 @@ func TestGenerate(t *testing.T) {
 	}
 
 	if !strings.Contains(string(data), `package factories`) {
-		t.Errorf("factory file should contain package name, got: \n%s", data)
+		t.Fatalf("factory file should contain package name, got: \n%s", data)
 	}
 
 	if !strings.Contains(string(data), `func UserFactory(h facto.Helper)`) {
-		t.Errorf("factory file should contain func definition, got: \n%s", data)
+		t.Fatalf("factory file should contain func definition, got: \n%s", data)
 	}
 }
 
@@ -115,11 +115,11 @@ func TestGenerateDirExists(t *testing.T) {
 		}
 
 		if !strings.Contains(string(data), `package factories`) {
-			t.Errorf("factory file should contain package name, got: \n%s", data)
+			t.Fatalf("factory file should contain package name, got: \n%s", data)
 		}
 
 		if !strings.Contains(string(data), `func UserFactory(h facto.Helper)`) {
-			t.Errorf("factory file should contain func definition, got: \n%s", data)
+			t.Fatalf("factory file should contain func definition, got: \n%s", data)
 		}
 	})
 
@@ -142,7 +142,7 @@ func TestGenerateDirExists(t *testing.T) {
 		}
 
 		if !strings.Contains(string(data), `func UserFactory(h facto.Helper)`) {
-			t.Errorf("factory file should contain func definition, got: \n%s", data)
+			t.Fatalf("factory file should contain func definition, got: \n%s", data)
 		}
 	})
 
@@ -170,7 +170,7 @@ func TestGenerateDirExists(t *testing.T) {
 		}
 
 		if !strings.Contains(string(data), `func UserFactory(h facto.Helper)`) {
-			t.Errorf("factory file should contain func definition, got: \n%s", data)
+			t.Fatalf("factory file should contain func definition, got: \n%s", data)
 		}
 	})
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -14,13 +14,13 @@ func TestHelperNamedUUID(t *testing.T) {
 	u2 := h.NamedUUID("something")
 
 	if u.String() != u2.String() {
-		t.Errorf("NamedUUIDs should be the same")
+		t.Fatalf("NamedUUIDs should be the same")
 	}
 
 	u3 := h.NamedUUID("something else")
 
 	if u.String() == u3.String() {
-		t.Errorf("Diferent named UUIDS should result in different values")
+		t.Fatalf("Diferent named UUIDS should result in different values")
 	}
 }
 
@@ -31,11 +31,11 @@ func TestHelperOneOf(t *testing.T) {
 		options := []string{"a", "b", "c"}
 		s, ok := h.OneOf("a", "b", "c").(string)
 		if !ok {
-			t.Errorf("OneOf should return a string")
+			t.Fatalf("OneOf should return a string")
 		}
 
 		if strings.Contains(strings.Join(options, "|"), s) == false {
-			t.Errorf("OneOf should return one of the options")
+			t.Fatalf("OneOf should return one of the options")
 		}
 	})
 
@@ -48,18 +48,18 @@ func TestHelperOneOf(t *testing.T) {
 
 		s, ok := h.OneOf(StatusOpen, StatusClosed).(Status)
 		if !ok {
-			t.Errorf("OneOf should return a Status")
+			t.Fatalf("OneOf should return a Status")
 		}
 
 		if s != StatusOpen && s != StatusClosed {
-			t.Errorf("OneOf should return one of the Status passed")
+			t.Fatalf("OneOf should return one of the Status passed")
 		}
 	})
 
 	t.Run("Empty", func(t *testing.T) {
 		s := h.OneOf()
 		if s != nil {
-			t.Errorf("OneOf should return Nil")
+			t.Fatalf("OneOf should return Nil")
 		}
 	})
 


### PR DESCRIPTION
This PR adds Create and CreateN which will allow developers to define custom Creators that developers would use to persist data for testing purposes. If no Creator is specified then those 2 methods return an error. While on it I noticed we have 89% coverage, nice.