### PR TITLE
Update gofrs/uuid to v5 for PostgreSQL 18 Compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.16.x"
-          - "1.17.x"
+          - "1.21.x"
+          - "1.22.x"
         os:
           - "macos-latest"
           - "windows-latest"

--- a/facto_test.go
+++ b/facto_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/gofrs/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/wawandco/facto"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/wawandco/facto
 
-go 1.16
+go 1.21
+
+toolchain go1.24.0
 
 require (
-	github.com/brianvoe/gofakeit/v6 v6.7.1
-	github.com/gofrs/uuid v4.0.0+incompatible
+	github.com/brianvoe/gofakeit/v6 v6.28.0
+	github.com/gofrs/uuid/v5 v5.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/brianvoe/gofakeit/v6 v6.7.1 h1:b7qWTFee06udGZL8yw9XQd+gtMD2WRLBPILBt6yVbMM=
 github.com/brianvoe/gofakeit/v6 v6.7.1/go.mod h1:palrJUk4Fyw38zIFB/uBZqsgzW5VsNllhHKKwAebzew=
-github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
-github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=
+github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
+github.com/gofrs/uuid/v5 v5.3.2 h1:2jfO8j3XgSwlz/wHqemAEugfnTlikAYHhnqQ8Xh4fE0=
+github.com/gofrs/uuid/v5 v5.3.2/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=

--- a/helper.go
+++ b/helper.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
-	"github.com/gofrs/uuid"
+	"github.com/gofrs/uuid/v5"
 )
 
 // Helper gets injected into the factory and provides convenience methods
@@ -40,8 +40,9 @@ func (h Helper) NamedUUID(name string) uuid.UUID {
 // ...
 // u := User{
 // // here the value of the field is one of the passed elements.
-//	Status: OneOf(UserStatusActive, UserStatusInactive).(UserStatus)
-// }
+//
+//		Status: OneOf(UserStatusActive, UserStatusInactive).(UserStatus)
+//	}
 func (h Helper) OneOf(values ...interface{}) interface{} {
 	if len(values) == 0 {
 		return nil


### PR DESCRIPTION
PostgreSQL 18 introduces built-in support for UUIDv7 via extensions. However, the current version of the gofrs/uuid library used in this project is not compatible with UUIDv7.
To address this, I'm updating gofrs/uuid to version 5, which includes support for UUIDv7 and ensures compatibility with PostgreSQL 18.